### PR TITLE
fix: テーマ切り替えボタンの初期表示を修正

### DIFF
--- a/app/components/ui/theme-switch.tsx
+++ b/app/components/ui/theme-switch.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react'
 
 export const ThemeSwitch = () => {
   const [mounted, setMounted] = useState(false)
-  const { theme, setTheme } = useTheme()
+  const { resolvedTheme, setTheme } = useTheme()
 
   useEffect(() => {
     setMounted(true)
@@ -17,11 +17,11 @@ export const ThemeSwitch = () => {
 
   return (
     <button
-      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
       className="fixed top-4 right-4 p-2 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
       aria-label="テーマ切り替え"
     >
-      {theme === 'dark' ? (
+      {resolvedTheme === 'dark' ? (
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"


### PR DESCRIPTION
## 概要
システムがダークモード設定時に、テーマ切り替えボタンの初期表示と動作が不自然になる問題を修正しました。

## 修正内容
- `useTheme`から`resolvedTheme`を取得するように変更
- システムのテーマ設定と表示状態を正しく同期

## 動作確認済み
- システム設定：ライトモード → 正しく表示
- システム設定：ダークモード → 正しく表示
- テーマ切り替えボタンのクリック動作