### PR TITLE
ops(ci): pin GitHub Actions to specific commit hashes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: 'npm'
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./out
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
# Overview
Update GitHub Actions versions from semantic versioning (e.g., v4) to pinned commit hashes for better security and stability.

## Changes
Pin the following actions to specific commit hashes:
- actions/checkout: v4 → v4.2.2 (11bd719)
- actions/setup-node: v4 → v4.4.0 (4993ea5)
- actions/upload-pages-artifact: v3 → v3.0.1 (56afc60)
- actions/deploy-pages: v4 → v4.0.5 (d6db901)

## Motivation
- Following security best practices by pinning action versions to specific commit hashes
- Prevent unexpected changes from minor or patch version updates
- Improve workflow reproducibility and stability

## Scope
- Only affects GitHub Pages deployment workflow
- No impact on existing functionality

## Verification
- [x] GitHub Pages deployment completes successfully
- [x] Deployed site renders correctly